### PR TITLE
Scale trajectory to given duration as before

### DIFF
--- a/pr2eus_moveit/euslisp/robot-moveit.l
+++ b/pr2eus_moveit/euslisp/robot-moveit.l
@@ -624,12 +624,11 @@
          (send* self :send-trajectory (send traj :joint_trajectory) args))
      ret))
   (:trajectory-filter ;; simple trajectory for zero duration
-   (traj &key (copy) (total-time 5000.0) (minimum-time 0.001) (start-offset-time 0) (clear-velocities) &rest args &allow-other-keys)
+   (traj &key (copy) (total-time 5000.0) (start-offset-time 0) (clear-velocities) &rest args &allow-other-keys)
    "traj (moveit_msgs/RobotTrajectory): input trajectory"
    (let ((orig-total-time (send (send (car (last (send traj :joint_trajectory :points))) :time_from_start) :to-sec)))
      ;; check if valid filtering can be applied
-     (when (or (and minimum-time (> orig-total-time minimum-time))
-               (null start-offset-time)
+     (when (or (null start-offset-time)
                (null total-time))
        (ros::ros-debug ";; Trajectory filter is skipped")
        (return-from :trajectory-filter traj))

--- a/pr2eus_moveit/euslisp/robot-moveit.l
+++ b/pr2eus_moveit/euslisp/robot-moveit.l
@@ -559,11 +559,13 @@
      (setq ret (send* self :angle-vector-make-trajectory av args))
      (unless ret (return-from :angle-vector-motion-plan nil))
      (setq traj (send ret :trajectory))
-     (setq traj (send* self :trajectory-filter traj :start-offset-time start-offset-time :total-time reset-total-time args))
      (setq orig-total-time (send (send (car (last (send traj :joint_trajectory :points))) :time_from_start) :to-sec)) ;; [sec]
      (when (< orig-total-time 0.001)
-       (ros::ros-error "Trajectory has very short duration")
-       (return-from :angle-vector-motion-plan nil))
+       (unless reset-total-time
+         (ros::ros-error "Trajectory has very short duration")
+         (return-from :angle-vector-motion-plan nil))
+       (ros::ros-warn "reset Trajectory Total time")
+       (setq traj (send* self :trajectory-filter traj :start-offset-time start-offset-time :total-time reset-total-time args)))
      (ros::ros-info ";; Planned Trajectory Total Time ~7,3f [sec]" orig-total-time)
      (setq total-time
            (cond


### PR DESCRIPTION
Without this PR, duration passed to `:angle-vector-motion-plan` is ignored.
In the following case, Baxter moved in 0.15 sec though I passed `:total-time 5000`.
```
21.irteusgl$ send *ri* :angle-vector-motion-plan (send *baxter* :angle-vector) :total-time 5000 :ctype :larm-head-controller :move-arm :arms :start-offset-time 0 :clear-velocities t :use-torso nil
[ INFO] [1533641740.862674579]: [/default_robot_interface_1533637184621611166] [ROSEUS_ROSINFO] ;; Planned Trajectory Total Time   0.150 [sec]
[ INFO] [1533641740.862830633]: [/default_robot_interface_1533637184621611166] [ROSEUS_ROSINFO] ;; Scaled Trajectory Total Time 0.150(5.000) [sec]
[ INFO] [1533641740.862897446]: [/default_robot_interface_1533637184621611166] [ROSEUS_ROSINFO] ;; generated 10 points for 5.0 sec using [both_arms] group
[ INFO] [1533641740.862972298]: [/default_robot_interface_1533637184621611166] [ROSEUS_ROSINFO] ;; will send to (left_s0 left_s1 left_e0 left_e1 left_w0 left_w1 left_w2 left_gripper_prismatic_joint left_gripper_vacuum_pad_joint right_s0 right_s1 right_e0 right_e1 right_w0 right_w1 right_w2 right_gripper_prismatic_joint right_gripper_vacuum_pad_joint)
[ INFO] [1533641740.863179594]: [/default_robot_interface_1533637184621611166] [ROSEUS_ROSINFO] ;; send self :angle-vector :head-controller (#<controller-action-client #Xe78fb80 /robot/head/head_action>) (without planning)
[ INFO] [1533641740.890913809]: [/default_robot_interface_1533637184621611166] [ROSEUS_ROSINFO] ;; send self :send-trajectory :larm-head-controller
#<moveit_msgs::motionplanresponse #X176cd660>
```

For detailed information about fixes, see commit messages.